### PR TITLE
Add EMM preprocessing pipeline for linear regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# EMM Regression Framework
+
+This repository contains a lightweight framework that applies Exceptional Model Mining (EMM) as a preprocessing step to enhance linear regression models. The workflow mines subgroups on the training split using a fixed beam-search strategy, converts those subgroups into indicator features, and evaluates whether the augmented feature set improves predictive performance.
+
+## Framework structure
+
+```
+emm_framework/
+├── __init__.py
+├── emm.py            # Beam search implementation
+├── models.py         # Linear regression helpers and metrics
+├── pipeline.py       # Orchestrates the full workflow
+└── schema.py         # Predicate and schema primitives
+```
+
+An example script demonstrating end-to-end usage on the included dummy dataset lives in `examples/run_pipeline.py`.
+
+## Installation
+
+Create a virtual environment and install the dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage example
+
+```python
+import pandas as pd
+from emm_framework import (
+    AttributeSpec,
+    EMMRegressionPipeline,
+    SubgroupSchema,
+)
+
+# Load pre-cleaned data
+df = pd.read_csv("student_dummy_data.csv")
+train_df = df.sample(frac=0.8, random_state=42)
+test_df = df.drop(train_df.index)
+
+schema = SubgroupSchema.from_attributes(
+    [
+        AttributeSpec.numeric("num_clicks", [(0, 20), (20, 40), (40, None)]),
+        AttributeSpec.numeric("previous_grade", [(0, 70), (70, 85), (85, None)]),
+        AttributeSpec.numeric("homework_score", [(0, 70), (70, 85), (85, None)]),
+    ]
+)
+
+pipeline = EMMRegressionPipeline(schema)
+result = pipeline.run(
+    train_frame=train_df,
+    test_frame=test_df,
+    target="exam_grade",
+    features=["num_clicks", "previous_grade", "homework_score"],
+)
+
+print("Baseline test RMSE:", result.baseline_test.rmse)
+print("Augmented test RMSE:", result.augmented_test.rmse)
+for subgroup in result.subgroups:
+    print(subgroup.describe())
+```
+
+## Tests
+
+Run the demonstration script:
+
+```bash
+python examples/run_pipeline.py
+```

--- a/emm_framework/__init__.py
+++ b/emm_framework/__init__.py
@@ -1,0 +1,12 @@
+"""Exceptional Model Mining (EMM) regression framework."""
+
+from .pipeline import EMMRegressionPipeline, PipelineResult, ModelMetrics
+from .schema import AttributeSpec, SubgroupSchema
+
+__all__ = [
+    "EMMRegressionPipeline",
+    "PipelineResult",
+    "ModelMetrics",
+    "AttributeSpec",
+    "SubgroupSchema",
+]

--- a/emm_framework/emm.py
+++ b/emm_framework/emm.py
@@ -1,0 +1,139 @@
+"""Beam search Exceptional Model Mining implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+from .schema import Predicate, SubgroupDescriptor, SubgroupSchema
+
+# Fixed beam-search configuration (non-configurable as per framework design)
+_BEAM_WIDTH = 10
+_MAX_DEPTH = 3
+_MIN_COVERAGE = 0.1
+_TOP_K = 10
+
+
+@dataclass(frozen=True)
+class SubgroupResult:
+    """Container for a mined subgroup and its quality statistics."""
+
+    descriptor: SubgroupDescriptor
+    coverage: int
+    coverage_fraction: float
+    mean_residual: float
+    quality: float
+
+    def to_indicator(self, frame: pd.DataFrame) -> pd.Series:
+        """Return a boolean indicator of subgroup membership for each row."""
+        return self.descriptor.apply(frame)
+
+    def describe(self) -> Dict[str, object]:
+        """Dictionary summary for reporting or serialization."""
+        return {
+            "description": self.descriptor.describe(),
+            "coverage": self.coverage,
+            "coverage_fraction": self.coverage_fraction,
+            "mean_residual": self.mean_residual,
+            "quality": self.quality,
+        }
+
+
+@dataclass
+class _BeamNode:
+    descriptor: SubgroupDescriptor
+    mask: np.ndarray
+    used_attributes: Tuple[str, ...]
+    quality: float
+
+
+class BeamSearchEMM:
+    """Mine subgroups that explain systematic residuals via beam search."""
+
+    def __init__(
+        self,
+        frame: pd.DataFrame,
+        residuals: pd.Series,
+        schema: SubgroupSchema,
+    ) -> None:
+        if len(frame) != len(residuals):
+            raise ValueError("Frame and residuals must align.")
+        self._frame = frame.reset_index(drop=True)
+        self._residuals = residuals.reset_index(drop=True)
+        self._schema = schema
+        self._predicate_catalog = self._build_predicate_catalog(schema)
+
+    @staticmethod
+    def _build_predicate_catalog(schema: SubgroupSchema) -> Dict[str, List[Predicate]]:
+        catalog: Dict[str, List[Predicate]] = {}
+        for attribute in schema.attributes:
+            catalog[attribute.name] = attribute.iter_predicates()
+        return catalog
+
+    def run(self) -> List[SubgroupResult]:
+        n_rows = len(self._frame)
+        residuals = self._residuals.to_numpy()
+        all_results: List[SubgroupResult] = []
+
+        # Start with the empty subgroup (covers everyone)
+        initial_mask = np.ones(n_rows, dtype=bool)
+        initial_descriptor = SubgroupDescriptor(())
+        initial_node = _BeamNode(
+            descriptor=initial_descriptor,
+            mask=initial_mask,
+            used_attributes=tuple(),
+            quality=0.0,
+        )
+
+        current_beam: List[_BeamNode] = [initial_node]
+
+        for depth in range(_MAX_DEPTH):
+            next_beam: List[_BeamNode] = []
+            candidates: List[_BeamNode] = []
+
+            for node in current_beam:
+                available_attributes = [
+                    name for name in self._predicate_catalog.keys() if name not in node.used_attributes
+                ]
+                for attribute in available_attributes:
+                    for predicate in self._predicate_catalog[attribute]:
+                        new_mask = node.mask & predicate.apply(self._frame).to_numpy()
+                        coverage = new_mask.sum()
+                        coverage_fraction = coverage / n_rows if n_rows else 0.0
+                        if coverage == 0 or coverage_fraction < _MIN_COVERAGE:
+                            continue
+                        subgroup_residuals = residuals[new_mask]
+                        mean_residual = float(np.mean(subgroup_residuals))
+                        quality = float(abs(mean_residual) * np.sqrt(coverage))
+                        descriptor = SubgroupDescriptor(node.descriptor.predicates + (predicate,))
+                        new_node = _BeamNode(
+                            descriptor=descriptor,
+                            mask=new_mask,
+                            used_attributes=node.used_attributes + (attribute,),
+                            quality=quality,
+                        )
+                        candidates.append(new_node)
+
+                        all_results.append(
+                            SubgroupResult(
+                                descriptor=descriptor,
+                                coverage=coverage,
+                                coverage_fraction=coverage_fraction,
+                                mean_residual=mean_residual,
+                                quality=quality,
+                            )
+                        )
+
+            # Select the next beam based on quality
+            if not candidates:
+                break
+            candidates.sort(key=lambda node: node.quality, reverse=True)
+            next_beam = candidates[:_BEAM_WIDTH]
+            current_beam = next_beam
+
+        # Keep only the global top-k subgroups
+        all_results.sort(key=lambda result: result.quality, reverse=True)
+        return all_results[:_TOP_K]

--- a/emm_framework/models.py
+++ b/emm_framework/models.py
@@ -1,0 +1,37 @@
+"""Linear regression utilities for the EMM pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_squared_error, r2_score
+
+
+@dataclass
+class RegressionArtifacts:
+    """Store trained model and derived metrics."""
+
+    model: LinearRegression
+    predictions: pd.Series
+    metrics: Dict[str, float]
+
+
+def fit_linear_regression(features: pd.DataFrame, target: pd.Series) -> RegressionArtifacts:
+    """Fit an ordinary least squares regression model."""
+    regressor = LinearRegression()
+    regressor.fit(features, target)
+    predictions = pd.Series(regressor.predict(features), index=target.index)
+    metrics = compute_metrics(target, predictions)
+    return RegressionArtifacts(model=regressor, predictions=predictions, metrics=metrics)
+
+
+def compute_metrics(target: pd.Series, predictions: pd.Series) -> Dict[str, float]:
+    """Return RMSE and R^2 metrics."""
+    mse = mean_squared_error(target, predictions)
+    rmse = float(np.sqrt(mse))
+    r2 = float(r2_score(target, predictions))
+    return {"rmse": rmse, "r2": r2}

--- a/emm_framework/pipeline.py
+++ b/emm_framework/pipeline.py
@@ -1,0 +1,100 @@
+"""End-to-end orchestration of the EMM-enhanced regression workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence
+
+import pandas as pd
+
+from .emm import BeamSearchEMM, SubgroupResult
+from .models import compute_metrics, fit_linear_regression
+from .schema import SubgroupDescriptor, SubgroupSchema
+
+
+@dataclass(frozen=True)
+class ModelMetrics:
+    """RMSE and R^2 metrics for a particular split."""
+
+    rmse: float
+    r2: float
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """Summary of the pipeline run containing metrics and mined subgroups."""
+
+    baseline_train: ModelMetrics
+    baseline_test: ModelMetrics
+    augmented_train: ModelMetrics
+    augmented_test: ModelMetrics
+    subgroups: List[SubgroupResult]
+
+
+class EMMRegressionPipeline:
+    """Run EMM as preprocessing and augment linear regression with subgroup indicators."""
+
+    def __init__(self, schema: SubgroupSchema) -> None:
+        self._schema = schema
+        self._subgroups: List[SubgroupResult] = []
+
+    @property
+    def subgroups(self) -> Sequence[SubgroupResult]:
+        return self._subgroups
+
+    def run(
+        self,
+        train_frame: pd.DataFrame,
+        test_frame: pd.DataFrame,
+        target: str,
+        features: Sequence[str],
+    ) -> PipelineResult:
+        """Execute the full pipeline and return metrics."""
+        baseline_train_artifacts = fit_linear_regression(train_frame[list(features)], train_frame[target])
+        baseline_test_predictions = baseline_train_artifacts.model.predict(test_frame[list(features)])
+        baseline_test_metrics = compute_metrics(
+            test_frame[target], pd.Series(baseline_test_predictions, index=test_frame.index)
+        )
+
+        # Mine subgroups on training data using residuals from the baseline model
+        residuals = train_frame[target] - baseline_train_artifacts.predictions
+        emm = BeamSearchEMM(train_frame, residuals, self._schema)
+        self._subgroups = emm.run()
+
+        augmented_train, augmented_test = self._augment_frames(train_frame, test_frame)
+        augmented_features = list(features) + [col for col in augmented_train.columns if col.startswith("sg_")]
+
+        augmented_train_artifacts = fit_linear_regression(augmented_train[augmented_features], augmented_train[target])
+        augmented_test_predictions = augmented_train_artifacts.model.predict(augmented_test[augmented_features])
+        augmented_test_metrics = compute_metrics(
+            augmented_test[target], pd.Series(augmented_test_predictions, index=augmented_test.index)
+        )
+
+        return PipelineResult(
+            baseline_train=_as_model_metrics(baseline_train_artifacts.metrics),
+            baseline_test=_as_model_metrics(baseline_test_metrics),
+            augmented_train=_as_model_metrics(augmented_train_artifacts.metrics),
+            augmented_test=_as_model_metrics(augmented_test_metrics),
+            subgroups=self._subgroups,
+        )
+
+    def _augment_frames(
+        self,
+        train_frame: pd.DataFrame,
+        test_frame: pd.DataFrame,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Append subgroup indicator columns to train and test frames."""
+        train_augmented = train_frame.copy()
+        test_augmented = test_frame.copy()
+
+        for index, subgroup in enumerate(self._subgroups):
+            descriptor: SubgroupDescriptor = subgroup.descriptor
+            feature_name = descriptor.feature_token(index)
+            train_augmented[feature_name] = subgroup.to_indicator(train_frame).astype(int)
+            test_augmented[feature_name] = subgroup.to_indicator(test_frame).astype(int)
+
+        return train_augmented, test_augmented
+
+
+def _as_model_metrics(raw: Dict[str, float]) -> ModelMetrics:
+    return ModelMetrics(rmse=raw["rmse"], r2=raw["r2"])

--- a/emm_framework/schema.py
+++ b/emm_framework/schema.py
@@ -1,0 +1,172 @@
+"""Schema primitives for describing candidate EMM predicates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+
+PredicateValue = Union[str, int, float]
+CategoryDefinition = Union[PredicateValue, Sequence[PredicateValue]]
+NumericBin = Tuple[Optional[float], Optional[float]]
+
+
+@dataclass(frozen=True)
+class Predicate:
+    """Base class for attribute predicates."""
+
+    attribute: str
+
+    def apply(self, frame: pd.DataFrame) -> pd.Series:
+        raise NotImplementedError
+
+    def describe(self) -> str:
+        raise NotImplementedError
+
+    def token(self) -> str:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class CategoricalPredicate(Predicate):
+    """Predicate that matches rows where the attribute takes one of the categories."""
+
+    categories: Tuple[PredicateValue, ...]
+
+    def apply(self, frame: pd.DataFrame) -> pd.Series:
+        values = frame[self.attribute]
+        return values.isin(self.categories)
+
+    def describe(self) -> str:
+        formatted = ", ".join(map(str, self.categories))
+        return f"{self.attribute} in {{{formatted}}}"
+
+    def token(self) -> str:
+        safe = [str(cat).replace(" ", "_") for cat in self.categories]
+        joined = "_or_".join(safe)
+        return f"{self.attribute}_in_{joined}"
+
+
+@dataclass(frozen=True)
+class NumericRangePredicate(Predicate):
+    """Predicate that matches rows within an interval."""
+
+    lower: Optional[float]
+    upper: Optional[float]
+    include_lower: bool = True
+    include_upper: bool = False
+
+    def apply(self, frame: pd.DataFrame) -> pd.Series:
+        values = frame[self.attribute]
+        mask = pd.Series(np.ones(len(frame), dtype=bool), index=frame.index)
+        if self.lower is not None:
+            mask &= values >= self.lower if self.include_lower else values > self.lower
+        if self.upper is not None:
+            mask &= values <= self.upper if self.include_upper else values < self.upper
+        return mask
+
+    def describe(self) -> str:
+        lower = "-inf" if self.lower is None else f"{self.lower:g}"
+        upper = "inf" if self.upper is None else f"{self.upper:g}"
+        left_bracket = "[" if self.include_lower else "("
+        right_bracket = "]" if self.include_upper else ")"
+        return f"{self.attribute} in {left_bracket}{lower}, {upper}{right_bracket}"
+
+    def token(self) -> str:
+        lower = "min" if self.lower is None else str(self.lower).replace(".", "p")
+        upper = "max" if self.upper is None else str(self.upper).replace(".", "p")
+        left = "ge" if self.include_lower else "gt"
+        right = "le" if self.include_upper else "lt"
+        return f"{self.attribute}_{left}_{lower}_{right}_{upper}"
+
+
+@dataclass(frozen=True)
+class AttributeSpec:
+    """Specification of an attribute that can appear in subgroup descriptors."""
+
+    name: str
+    type: str  # "categorical" or "numeric"
+    categories: Tuple[Tuple[PredicateValue, ...], ...] = field(default_factory=tuple)
+    bins: Tuple[NumericBin, ...] = field(default_factory=tuple)
+
+    @staticmethod
+    def categorical(name: str, categories: Iterable[CategoryDefinition]) -> "AttributeSpec":
+        normalised: List[Tuple[PredicateValue, ...]] = []
+        for category in categories:
+            if isinstance(category, Sequence) and not isinstance(category, (str, bytes)):
+                normalised.append(tuple(category))
+            else:
+                normalised.append((category,))
+        return AttributeSpec(name=name, type="categorical", categories=tuple(normalised))
+
+    @staticmethod
+    def numeric(name: str, bins: Iterable[NumericBin]) -> "AttributeSpec":
+        return AttributeSpec(name=name, type="numeric", bins=tuple(bins))
+
+    def iter_predicates(self) -> List[Predicate]:
+        if self.type == "categorical":
+            return [CategoricalPredicate(self.name, cats) for cats in self.categories]
+        if self.type == "numeric":
+            predicates: List[Predicate] = []
+            for lower, upper in self.bins:
+                predicates.append(
+                    NumericRangePredicate(
+                        attribute=self.name,
+                        lower=lower,
+                        upper=upper,
+                        include_lower=True,
+                        include_upper=upper is None,
+                    )
+                )
+            return predicates
+        raise ValueError(f"Unsupported attribute type: {self.type}")
+
+
+@dataclass(frozen=True)
+class SubgroupDescriptor:
+    """Conjunction of predicates describing a subgroup."""
+
+    predicates: Tuple[Predicate, ...]
+
+    def apply(self, frame: pd.DataFrame) -> pd.Series:
+        if not self.predicates:
+            return pd.Series(np.ones(len(frame), dtype=bool), index=frame.index)
+        mask = pd.Series(np.ones(len(frame), dtype=bool), index=frame.index)
+        for predicate in self.predicates:
+            mask &= predicate.apply(frame)
+        return mask
+
+    def describe(self) -> str:
+        if not self.predicates:
+            return "<entire population>"
+        return " AND ".join(predicate.describe() for predicate in self.predicates)
+
+    def feature_token(self, index: int) -> str:
+        if not self.predicates:
+            return f"sg_all_{index}"
+        parts = [predicate.token() for predicate in self.predicates]
+        token = "_and_".join(parts)
+        return f"sg_{token}_{index}"
+
+
+@dataclass(frozen=True)
+class SubgroupSchema:
+    """Collection of attribute specifications allowed in the descriptive space."""
+
+    attributes: Tuple[AttributeSpec, ...]
+
+    @staticmethod
+    def from_attributes(attributes: Iterable[AttributeSpec]) -> "SubgroupSchema":
+        return SubgroupSchema(attributes=tuple(attributes))
+
+    def all_predicates(self) -> List[Predicate]:
+        predicates: List[Predicate] = []
+        for attribute in self.attributes:
+            predicates.extend(attribute.iter_predicates())
+        return predicates
+
+    def attribute_names(self) -> List[str]:
+        return [attribute.name for attribute in self.attributes]

--- a/examples/run_pipeline.py
+++ b/examples/run_pipeline.py
@@ -1,0 +1,41 @@
+"""Run the EMM regression pipeline on the dummy student dataset."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from emm_framework import AttributeSpec, EMMRegressionPipeline, SubgroupSchema
+
+
+def main() -> None:
+    df = pd.read_csv("student_dummy_data.csv")
+    train_df = df.sample(frac=0.8, random_state=42)
+    test_df = df.drop(train_df.index)
+
+    schema = SubgroupSchema.from_attributes(
+        [
+            AttributeSpec.numeric("num_clicks", [(0, 20), (20, 40), (40, None)]),
+            AttributeSpec.numeric("previous_grade", [(0, 70), (70, 85), (85, None)]),
+            AttributeSpec.numeric("homework_score", [(0, 70), (70, 85), (85, None)]),
+        ]
+    )
+
+    pipeline = EMMRegressionPipeline(schema)
+    result = pipeline.run(
+        train_frame=train_df,
+        test_frame=test_df,
+        target="exam_grade",
+        features=["num_clicks", "previous_grade", "homework_score"],
+    )
+
+    print("Baseline train metrics:", result.baseline_train)
+    print("Baseline test metrics:", result.baseline_test)
+    print("Augmented train metrics:", result.augmented_train)
+    print("Augmented test metrics:", result.augmented_test)
+    print("\nTop subgroups:")
+    for subgroup in result.subgroups:
+        print(subgroup.describe())
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+pandas
+scikit-learn


### PR DESCRIPTION
## Summary
- implement an Exceptional Model Mining beam-search module with subgroup schema definitions and linear regression utilities
- create a pipeline that mines subgroups on the training split, augments features, and reports baseline vs augmented metrics
- document the framework and add an example script plus dependency list for running the workflow

## Testing
- ❌ `python examples/run_pipeline.py` *(fails: missing pandas because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e8c27490832093ffccc6ff70f049